### PR TITLE
feat: 支持对新Tensor模版参数的解析。

### DIFF
--- a/clang/tools/translator/dacppLib/include/myTensor.hpp
+++ b/clang/tools/translator/dacppLib/include/myTensor.hpp
@@ -357,9 +357,7 @@ public:
     Tensor<ImplType, 1> operator[](RegularSplit sp) const {
         return *this;
     }
-    ImplType& operator[](Index sp) const {
-        return 0;
-    }
+    ImplType& operator[](Index sp) const ;
     ImplType& slice(int dimIdx, int idx) const {
         int offset = this->offset_ + idx * this->stride_.get()[dimIdx];
         return this->data_.get()[offset];

--- a/clang/tools/translator/parser/include/Param.h
+++ b/clang/tools/translator/parser/include/Param.h
@@ -33,11 +33,13 @@ public:
     void setName(std::string name);
     std::string getName();
 
-    void setShape(int size);
-    void setShape(int idx, int size);
-    int getShape(int idx);
-    int getDim();
+    void __attribute__(( unused, deprecated )) setShape(int size) ;
+    void __attribute__(( unused, deprecated )) setShape(int idx, int size);
+    int __attribute__(( unused, deprecated )) getShape(int idx);
+    int __attribute__(( unused, deprecated )) getDim();
 
+    /* 维度：通过tensor的第二个模版参数获取。  */
+    int dim;
 };
 
 

--- a/clang/tools/translator/parser/lib/Param.cpp
+++ b/clang/tools/translator/parser/lib/Param.cpp
@@ -1,3 +1,4 @@
+#include "llvm/Support/raw_ostream.h"
 #include <string>
 
 #include "Param.h"
@@ -17,15 +18,55 @@ bool dacppTranslator::Param::getRw() {
 }
 
 void dacppTranslator::Param::setType(std::string type) {
+    const char *temp;
+    const char *begin;
+    const char *end;
+    const char *comma;
+    char *btype, *dim;
+    int i;
+    
+    /* example: Tensor<int, 2>  */
+    temp = type.c_str();
+    begin = strchr (temp, '<');
+    end = strrchr (temp, '>');
+    comma = strrchr (temp, ',');
+
+    /* NO error output, just check.  */
+    assert(!strncmp(temp, "Tensor", 6) ||
+           !strncmp(temp, "const Tensor", strlen("const Tensor")));
+    assert (begin && end && begin < end);
+
     this->type = type;
-    if(type.find("Tensor<int>") != -1) {
-        this->basicType = "int";
-    }
-    else if(type.find("Tensor<float>") != -1) {
-        this->basicType =  "float";
-    }
-    else {
-        this->basicType =  "double";
+
+    if (!comma || strchr(comma, '<') || strchr(comma, '(') ||
+        strchr(comma, '{') ||
+        (strchr(comma, '>') && end != strchr(comma, '>')) ||
+        strchr(comma, ')') || strchr(comma, '}')) {
+      /* Tensor has only 1 argument.  */
+      btype = (char *)malloc(sizeof(char) * (end - begin));
+      for (i = 1; begin + i < end; ++i)
+        btype[i - 1] = begin[i];
+      btype[i - 1] = '\0';
+      this->basicType = btype;
+      free(btype);
+    } else {
+      /* Tensor has 2 arguments.  */
+
+      /* parse the first argument.  */
+      btype = (char *)malloc(sizeof(char) * (comma - begin));
+      for (i = 1; begin + i < comma; ++i)
+        btype[i - 1] = begin[i];
+      btype[i - 1] = '\0';
+      this->basicType = btype;
+      free(btype);
+
+      /* parse the second argument.  */
+      dim = (char *)malloc(sizeof(char) * (end - comma));
+      for (i = 1; comma + i < end; ++i)
+        dim[i - 1] = comma[i];
+      dim[i - 1] = '\0';
+      this->dim = atoi(dim);
+      free(dim);
     }
 }
 
@@ -58,7 +99,7 @@ int dacppTranslator::Param::getShape(int idx) {
 }
 
 int dacppTranslator::Param::getDim() {
-    return shape.size();
+    return shape.size(); 
 }
 
 /*


### PR DESCRIPTION
与旧Tensor相比，新Tensor增加了很多特性。然而，我们只需要解析新增加的模版参数即可。
另外，由于我们并未彻底弃用旧Tensor，因此我们仍然支持旧Tensor模版参数的解析。
需要注意的是，由于条件所限，我们使用字符串进行解析。将来我们也许会考虑使用类似于TypePrinter的方式对其进行解析。