### PR TITLE
fix: make the bug out of box.

### DIFF
--- a/clang/tools/translator/parser/lib/Param.cpp
+++ b/clang/tools/translator/parser/lib/Param.cpp
@@ -32,8 +32,12 @@ void dacppTranslator::Param::setType(std::string type) {
     comma = strrchr (temp, ',');
 
     /* NO error output, just check.  */
-    assert(!strncmp(temp, "Tensor", 6) ||
-           !strncmp(temp, "const Tensor", strlen("const Tensor")));
+    if (strncmp (temp, "Tensor", 6) && 
+        strncmp (temp, "const Tensor", strlen ("const Tensor"))) {
+        this->basicType = "double";
+        return;
+    }
+
     assert (begin && end && begin < end);
 
     this->type = type;


### PR DESCRIPTION
While parsing the arguments of `calc', we treat the types that are not wrapped by tensor as `double', which is the same as the old behavior.